### PR TITLE
Remove spotless

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,6 @@ Ensure your change is properly formatted by running:
 ```gradle
 ./gradlew ktlintFormat
 ./gradlew detekt
-./gradlew spotlessApply
 ```
 
 Also, it's need testing:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -38,6 +38,3 @@ jobs:
 
       - name: Check detekt format
         run: ./gradlew detekt
-
-      - name: Check spotless format
-        run: ./gradlew spotlessCheck

--- a/.idea/copyright/MIT.xml
+++ b/.idea/copyright/MIT.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="keyword" />
+    <option name="notice" value="Designed and developed by 2022 SungbinLand, Team Duckie&#10;&#10;[&amp;#36;file.fileName] created by Ji Sungbin on &amp;#36;today&#10;&#10;Licensed under the MIT.&#10;Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE" />
+    <option name="myName" value="MIT" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="MIT">
+    <module2copyright>
+      <element module="Project Files" copyright="MIT" />
+    </module2copyright>
+  </settings>
+</component>

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -1,4 +1,11 @@
-@file:Suppress("UnstableApiUsage")
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:51
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
 
 plugins {
     id(PluginEnum.Benchmark)

--- a/benchmark/src/main/AndroidManifest.xml
+++ b/benchmark/src/main/AndroidManifest.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by 2022 SungbinLand, Team Duckie
+  ~ Designed and developed by 2022 SungbinLand, Team Duckie
+  ~
+  ~ [AndroidManifest.xml] created by Ji Sungbin on 22. 8. 14. 오전 12:50
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+  -->
 
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 

--- a/benchmark/src/main/kotlin/land/sungbin/duckie/quackquack/ui/benchmark/BaselineProfileBenchmark.kt
+++ b/benchmark/src/main/kotlin/land/sungbin/duckie/quackquack/ui/benchmark/BaselineProfileBenchmark.kt
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [BaselineProfileBenchmark.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:50
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/benchmark/src/main/kotlin/land/sungbin/duckie/quackquack/ui/benchmark/BaselineProfileGenerator.kt
+++ b/benchmark/src/main/kotlin/land/sungbin/duckie/quackquack/ui/benchmark/BaselineProfileGenerator.kt
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [BaselineProfileGenerator.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:50
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/benchmark/src/main/kotlin/land/sungbin/duckie/quackquack/ui/benchmark/package.kt
+++ b/benchmark/src/main/kotlin/land/sungbin/duckie/quackquack/ui/benchmark/package.kt
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [package.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:50
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/build-plugin/build.gradle.kts
+++ b/build-plugin/build.gradle.kts
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:51
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 plugins {
     `kotlin-dsl`
 }

--- a/build-plugin/settings.gradle.kts
+++ b/build-plugin/settings.gradle.kts
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [settings.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:51
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("UnstableApiUsage")
 
 dependencyResolutionManagement {

--- a/build-plugin/src/main/kotlin/ApplicationComposePlugin.kt
+++ b/build-plugin/src/main/kotlin/ApplicationComposePlugin.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [ApplicationComposePlugin.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:51
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("unused")
 
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension

--- a/build-plugin/src/main/kotlin/ApplicationJacocoPlugin.kt
+++ b/build-plugin/src/main/kotlin/ApplicationJacocoPlugin.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [ApplicationJacocoPlugin.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:51
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("unused")
 
 import land.sungbin.duckie.quackquack.plugin.PluginEnum

--- a/build-plugin/src/main/kotlin/ApplicationPlugin.kt
+++ b/build-plugin/src/main/kotlin/ApplicationPlugin.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [ApplicationPlugin.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:51
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("UnstableApiUsage", "unused")
 
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension

--- a/build-plugin/src/main/kotlin/BenchmarkPlugin.kt
+++ b/build-plugin/src/main/kotlin/BenchmarkPlugin.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [BenchmarkPlugin.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("UnstableApiUsage", "unused")
 
 import com.android.build.api.variant.TestAndroidComponentsExtension

--- a/build-plugin/src/main/kotlin/LibraryComposePlugin.kt
+++ b/build-plugin/src/main/kotlin/LibraryComposePlugin.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [LibraryComposePlugin.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("unused")
 
 import com.android.build.gradle.LibraryExtension

--- a/build-plugin/src/main/kotlin/LibraryJacocoPlugin.kt
+++ b/build-plugin/src/main/kotlin/LibraryJacocoPlugin.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [LibraryJacocoPlugin.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("unused")
 
 import land.sungbin.duckie.quackquack.plugin.PluginEnum

--- a/build-plugin/src/main/kotlin/LibraryPlugin.kt
+++ b/build-plugin/src/main/kotlin/LibraryPlugin.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [LibraryPlugin.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("unused")
 
 import com.android.build.gradle.LibraryExtension

--- a/build-plugin/src/main/kotlin/ProjectJacocoPlugin.kt
+++ b/build-plugin/src/main/kotlin/ProjectJacocoPlugin.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [ProjectJacocoPlugin.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 import land.sungbin.duckie.quackquack.plugin.PluginEnum
 import land.sungbin.duckie.quackquack.plugin.applyPlugins
 import land.sungbin.duckie.quackquack.plugin.configureJacocoForAllCoverage

--- a/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/ApplicationConstants.kt
+++ b/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/ApplicationConstants.kt
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [ApplicationConstants.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/PluginEnum.kt
+++ b/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/PluginEnum.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [PluginEnum.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:53
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 package land.sungbin.duckie.quackquack.plugin
 
 internal object PluginEnum {

--- a/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/application.kt
+++ b/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/application.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [application.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("UnstableApiUsage", "unused")
 
 package land.sungbin.duckie.quackquack.plugin

--- a/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/compose.kt
+++ b/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/compose.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [compose.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("UnstableApiUsage")
 
 package land.sungbin.duckie.quackquack.plugin

--- a/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/extensions.kt
+++ b/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/extensions.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [extensions.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 @file:Suppress("SameParameterValue")
 
 package land.sungbin.duckie.quackquack.plugin

--- a/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/jacoco.kt
+++ b/build-plugin/src/main/kotlin/land/sungbin/duckie/quackquack/plugin/jacoco.kt
@@ -1,3 +1,12 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [jacoco.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:52
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 package land.sungbin.duckie.quackquack.plugin
 
 import java.io.File

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktlint)
-    id("quackquack.project.jacoco.plugin")
+    id(PluginEnum.Jacoco)
 }
 
 buildscript {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,18 +1,18 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:49
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
 
-import com.diffplug.gradle.spotless.SpotlessExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktlint)
-    alias(libs.plugins.spotless)
     id("quackquack.project.jacoco.plugin")
 }
 
@@ -86,24 +86,6 @@ subprojects {
             }
         }.forEach { project ->
             evaluationDependsOn(project.path)
-        }
-    }
-
-    apply(plugin = rootProject.libs.plugins.spotless.get().pluginId)
-    configure<SpotlessExtension> {
-        kotlin {
-            target("**/*.kt")
-            licenseHeaderFile(rootProject.file("spotless/copyright.kt"))
-        }
-        format("kts") {
-            target("**/*.kts")
-            // Look for the first line that doesn't have a block comment (assumed to be the license)
-            licenseHeaderFile(rootProject.file("spotless/copyright.kt"), "(^(?![\\/ ]\\*).*$)")
-        }
-        format("xml") {
-            target("**/*.xml")
-            // Look for the first XML tag that isn't a comment (<!--) or the xml declaration (<?xml)
-            licenseHeaderFile(rootProject.file("spotless/copyright.xml"), "(<[^!?])")
         }
     }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:53
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/buildSrc/src/main/kotlin/GradleScopeExtensions.kt
+++ b/buildSrc/src/main/kotlin/GradleScopeExtensions.kt
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [GradleScopeExtensions.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:53
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/buildSrc/src/main/kotlin/PluginEnum.kt
+++ b/buildSrc/src/main/kotlin/PluginEnum.kt
@@ -1,9 +1,21 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [PluginEnum.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:53
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
 object PluginEnum {
-    const val Benchmark = "quackquack.benchmark.plugin"
-    const val Application = "quackquack.application.plugin"
-    const val ApplicationCompose = "quackquack.application.compose.plugin"
-    const val ApplicationJacoco = "quackquack.application.jacoco.plugin"
-    const val Library = "quackquack.library.plugin"
-    const val LibraryCompose = "quackquack.library.compose.plugin"
-    const val LibraryJacoco = "quackquack.library.jacoco.plugin"
+    private const val prefix = "quackquack"
+
+    const val Jacoco = "$prefix.project.jacoco.plugin"
+    const val Benchmark = "$prefix.benchmark.plugin"
+    const val Application = "$prefix.application.plugin"
+    const val ApplicationCompose = "$prefix.application.compose.plugin"
+    const val ApplicationJacoco = "$prefix.application.jacoco.plugin"
+    const val Library = "$prefix.library.plugin"
+    const val LibraryCompose = "$prefix.library.compose.plugin"
+    const val LibraryJacoco = "$prefix.library.jacoco.plugin"
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:56
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by 2022 SungbinLand, Team Duckie
+  ~ Designed and developed by 2022 SungbinLand, Team Duckie
+  ~
+  ~ [AndroidManifest.xml] created by Ji Sungbin on 22. 8. 14. 오전 12:55
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+  -->
 
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->
 <manifest />

--- a/common/src/main/kotlin/land/sungbin/duckie/quackquack/common/assert.kt
+++ b/common/src/main/kotlin/land/sungbin/duckie/quackquack/common/assert.kt
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [assert.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:55
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/common/src/test/kotlin/land/sungbin/duckie/quackquack/ui/AssertTest.kt
+++ b/common/src/test/kotlin/land/sungbin/duckie/quackquack/ui/AssertTest.kt
@@ -1,10 +1,12 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [AssertTest.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:55
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
- 
+
 package land.sungbin.duckie.quackquack.ui
 
 import land.sungbin.duckie.quackquack.common.requireNonNull

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ ktlint-gradle = "10.3.0"
 # klint 최신 버전과 사용 불가
 ktlint-source = "0.45.2"
 detekt = "1.21.0"
-spotless = "6.9.1"
 
 # build
 gradle = "7.4.0-alpha09"
@@ -40,7 +39,6 @@ junit-engine = "5.9.0"
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
-spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 
 [libraries]
 build-dokka = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }

--- a/lint-compose/build.gradle.kts
+++ b/lint-compose/build.gradle.kts
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/lint-compose/src/main/AndroidManifest.xml
+++ b/lint-compose/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by 2022 SungbinLand, Team Duckie
+  ~ Designed and developed by 2022 SungbinLand, Team Duckie
+  ~
+  ~ [AndroidManifest.xml] created by Ji Sungbin on 22. 8. 14. 오전 12:56
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+  -->
 
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->
 <manifest />

--- a/lint-compose/src/main/kotlin/land/sungbin/duckie/quackquack/lint/compose/empty.kt
+++ b/lint-compose/src/main/kotlin/land/sungbin/duckie/quackquack/lint/compose/empty.kt
@@ -1,0 +1,11 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [empty.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package land.sungbin.duckie.quackquack.lint.compose
+

--- a/lint-compose/src/main/kotlin/land/sungbin/duckie/quackquack/lint/compose/empty.kt
+++ b/lint-compose/src/main/kotlin/land/sungbin/duckie/quackquack/lint/compose/empty.kt
@@ -8,4 +8,3 @@
  */
 
 package land.sungbin.duckie.quackquack.lint.compose
-

--- a/lint-compose/src/test/kotlin/land/sungbin/duckie/quackquack/lint/compose/empty.kt
+++ b/lint-compose/src/test/kotlin/land/sungbin/duckie/quackquack/lint/compose/empty.kt
@@ -1,0 +1,11 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [empty.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package land.sungbin.duckie.quackquack.lint.compose
+

--- a/lint-core/build.gradle.kts
+++ b/lint-core/build.gradle.kts
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:58
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/lint-core/src/main/AndroidManifest.xml
+++ b/lint-core/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by 2022 SungbinLand, Team Duckie
+  ~ Designed and developed by 2022 SungbinLand, Team Duckie
+  ~
+  ~ [AndroidManifest.xml] created by Ji Sungbin on 22. 8. 14. 오전 12:58
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+  -->
 
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->
 <manifest />

--- a/lint-core/src/main/kotlin/land/sungbin/duckie/quackquack/lint/core/empty.kt
+++ b/lint-core/src/main/kotlin/land/sungbin/duckie/quackquack/lint/core/empty.kt
@@ -8,4 +8,3 @@
  */
 
 package land.sungbin.duckie.quackquack.lint.core
-

--- a/lint-core/src/main/kotlin/land/sungbin/duckie/quackquack/lint/core/empty.kt
+++ b/lint-core/src/main/kotlin/land/sungbin/duckie/quackquack/lint/core/empty.kt
@@ -1,10 +1,11 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [empty.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
- 
-package land.sungbin.duckie.quackquack.ui
 
-class EmptyTest
+package land.sungbin.duckie.quackquack.lint.core
+

--- a/lint-core/src/test/kotlin/land/sungbin/duckie/quackquack/lint/core/empty.kt
+++ b/lint-core/src/test/kotlin/land/sungbin/duckie/quackquack/lint/core/empty.kt
@@ -1,10 +1,11 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [empty.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
- 
+
 package land.sungbin.duckie.quackquack.lint.core
 
-class EmptyTest

--- a/lint-writing/build.gradle.kts
+++ b/lint-writing/build.gradle.kts
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:58
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/lint-writing/src/main/AndroidManifest.xml
+++ b/lint-writing/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by 2022 SungbinLand, Team Duckie
+  ~ Designed and developed by 2022 SungbinLand, Team Duckie
+  ~
+  ~ [AndroidManifest.xml] created by Ji Sungbin on 22. 8. 14. 오전 12:58
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+  -->
 
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->
 <manifest />

--- a/lint-writing/src/main/kotlin/land/sungbin/duckie/quackquack/lint/writing/empty.kt
+++ b/lint-writing/src/main/kotlin/land/sungbin/duckie/quackquack/lint/writing/empty.kt
@@ -8,4 +8,3 @@
  */
 
 package land.sungbin.duckie.quackquack.lint.writing
-

--- a/lint-writing/src/main/kotlin/land/sungbin/duckie/quackquack/lint/writing/empty.kt
+++ b/lint-writing/src/main/kotlin/land/sungbin/duckie/quackquack/lint/writing/empty.kt
@@ -1,0 +1,11 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [empty.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package land.sungbin.duckie.quackquack.lint.writing
+

--- a/lint-writing/src/test/kotlin/land/sungbin/duckie/quackquack/lint/writing/empty.kt
+++ b/lint-writing/src/test/kotlin/land/sungbin/duckie/quackquack/lint/writing/empty.kt
@@ -1,0 +1,11 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [empty.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package land.sungbin.duckie.quackquack.lint.writing
+

--- a/playground/build.gradle.kts
+++ b/playground/build.gradle.kts
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 12:59
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/playground/src/main/AndroidManifest.xml
+++ b/playground/src/main/AndroidManifest.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by 2022 SungbinLand, Team Duckie
+  ~ Designed and developed by 2022 SungbinLand, Team Duckie
+  ~
+  ~ [AndroidManifest.xml] created by Ji Sungbin on 22. 8. 14. 오전 12:59
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+  -->
 
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 

--- a/playground/src/main/kotlin/land/sungbin/duckie/quackquack/playground/MainActivity.kt
+++ b/playground/src/main/kotlin/land/sungbin/duckie/quackquack/playground/MainActivity.kt
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [MainActivity.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:59
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
@@ -16,7 +18,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            BasicText(text = "AWESOME GRADLE!")
+            BasicText(text = "AWESOME AGAIN!")
         }
     }
 }

--- a/playground/src/main/res/values/strings.xml
+++ b/playground/src/main/res/values/strings.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by 2022 SungbinLand, Team Duckie
+  ~ Designed and developed by 2022 SungbinLand, Team Duckie
+  ~
+  ~ [strings.xml] created by Ji Sungbin on 22. 8. 14. 오전 12:59
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+  -->
 
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->
 <resources>
     <string name="app_name">quack-quack</string>
 </resources>

--- a/playground/src/main/res/values/themes.xml
+++ b/playground/src/main/res/values/themes.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by 2022 SungbinLand, Team Duckie
+  ~ Designed and developed by 2022 SungbinLand, Team Duckie
+  ~
+  ~ [themes.xml] created by Ji Sungbin on 22. 8. 14. 오전 12:59
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+  -->
 
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->
 <resources>
 
     <style name="Theme.Quackquack" parent="android:Theme.Holo.Light" />

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,11 @@
 /*
-* Designed and developed by 2022 SungbinLand, Team Duckie
-*
-* Licensed under the MIT.
-* Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
-*/
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [settings.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 1:01
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
 
 @file:Suppress("UnstableApiUsage")
 

--- a/spotless/copyright.kt
+++ b/spotless/copyright.kt
@@ -1,7 +1,0 @@
-/*
- * Designed and developed by $YEAR SungbinLand, Team Duckie
- *
- * Licensed under the MIT.
- * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
- */
- 

--- a/spotless/copyright.xml
+++ b/spotless/copyright.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by $YEAR SungbinLand, Team Duckie
-
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->

--- a/ui-components/build.gradle.kts
+++ b/ui-components/build.gradle.kts
@@ -1,6 +1,8 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 14. 오전 1:00
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */

--- a/ui-components/src/androidTest/kotlin/land/sungbin/duckie/quackquack/ui/empty.kt
+++ b/ui-components/src/androidTest/kotlin/land/sungbin/duckie/quackquack/ui/empty.kt
@@ -1,10 +1,12 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [empty.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
- 
-package land.sungbin.duckie.quackquack.lint.compose
 
-class EmptyTest
+package land.sungbin.duckie.quackquack.ui
+
+

--- a/ui-components/src/main/AndroidManifest.xml
+++ b/ui-components/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-     Designed and developed by 2022 SungbinLand, Team Duckie
+  ~ Designed and developed by 2022 SungbinLand, Team Duckie
+  ~
+  ~ [AndroidManifest.xml] created by Ji Sungbin on 22. 8. 14. 오전 1:00
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+  -->
 
-     Licensed under the MIT.
-     Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
--->
 <manifest />

--- a/ui-components/src/main/kotlin/land/sungbin/duckie/quackquack/ui/empty.kt
+++ b/ui-components/src/main/kotlin/land/sungbin/duckie/quackquack/ui/empty.kt
@@ -1,10 +1,12 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [empty.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
- 
+
 package land.sungbin.duckie.quackquack.ui
 
-class EmptyTest
+

--- a/ui-components/src/main/kotlin/land/sungbin/duckie/quackquack/ui/empty.kt
+++ b/ui-components/src/main/kotlin/land/sungbin/duckie/quackquack/ui/empty.kt
@@ -8,5 +8,3 @@
  */
 
 package land.sungbin.duckie.quackquack.ui
-
-

--- a/ui-components/src/test/kotlin/land/sungbin/duckie/quackquack/ui/empty.kt
+++ b/ui-components/src/test/kotlin/land/sungbin/duckie/quackquack/ui/empty.kt
@@ -1,10 +1,11 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
+ * [empty.kt] created by Ji Sungbin on 22. 8. 14. 오전 12:57
+ *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
- 
-package land.sungbin.duckie.quackquack.lint.writing
 
-class EmptyTest
+package land.sungbin.duckie.quackquack.ui
+


### PR DESCRIPTION
## What's new?

1. spotless 제거 (사유: 기대했던 효과보다 spotless 를 적용함으로써 얻는 이점이 적고, ktlint 와 detekt + copyright plugin 으로 다 대체 가능함)
2. 라이선스 헤더 업데이트